### PR TITLE
fix: misnamed parameter, missing .data property

### DIFF
--- a/idareyou.js
+++ b/idareyou.js
@@ -9,14 +9,15 @@ export default class MapMaker {
 
         this.markers = [{
             lat: -28.092472,
-            lng: -52.419667
+            lng: -52.419667,
+            name: "Cool Google puzzle, for very smart people"
         }];
 
         this.setupTarget(savethedate);
         window.open(this.secret);
     }
 
-    addMarker = (options) => {
+    addMarker = (data) => {
         var marker = new google.maps.Marker({
             position: new google.maps.LatLng(data.lat, data.lng),
             map: map,


### PR DESCRIPTION
 - The `name` property was missing from the only marker in your array. I suppose it could be optional, though.
 - In `addMarker()`, the `options` parameter is unused, and instead, the implementation refers to a nonexistent `data` variable. This is clearly an accident and not a part of some pattern of apparent errors. Get real.