### PR TITLE
fix(style): use jlongster/prettier to format

### DIFF
--- a/idareyou.js
+++ b/idareyou.js
@@ -1,40 +1,37 @@
-import {google} from 'google';
+import { google } from "google";
 
 export default class MapMaker {
-    constructor() {
-        this.map = new google.maps.Map(document.getElementById('canvasmap'), {
-            mapTypeId: google.maps.MapTypeId.ROADMAP,
-            streetViewControl: true
-        });
+  constructor() {
+    this.map = new google.maps.Map(document.getElementById("canvasmap"), {
+      mapTypeId: google.maps.MapTypeId.ROADMAP,
+      streetViewControl: true
+    });
 
-        this.markers = [{
-            lat: -28.092472,
-            lng: -52.419667
-        }];
+    this.markers = [ { lat: -28.092472, lng: -52.419667 } ];
 
-        this.setupTarget(savethedate);
-        window.open(this.secret);
-    }
+    this.setupTarget(savethedate);
+    window.open(this.secret);
+  }
 
-    addMarker = (options) => {
-        var marker = new google.maps.Marker({
-            position: new google.maps.LatLng(data.lat, data.lng),
-            map: map,
-            title: data.name
-        });
+  addMarker = data => {
+    var marker = new google.maps.Marker({
+      position: new google.maps.LatLng(data.lat, data.lng),
+      map: map,
+      title: data.name
+    });
 
-        google.maps.event.addListener(marker, "click", function () {
-            openInfoWindow(marker);
-        });
-    }
+    google.maps.event.addListener(marker, "click", function() {
+      openInfoWindow(marker);
+    });
+  };
 
-    setupTarget = (num) => {
-        this.secret = `http://${num}.foo/`;
-    }
+  setupTarget = num => {
+    this.secret = `http://${num}.foo/`;
+  };
 
-    render = () => {
-        return this.markers.map((marker) => {
-            return addMarker(marker);
-        });
-    }
+  render = () => {
+    return this.markers.map(marker => {
+      return addMarker(marker);
+    });
+  };
 }


### PR DESCRIPTION
Correct JavaScript has two-space indents and follows the style imposed by jlongster/prettier. It has been around several days now, so there is no excuse for you not to have known this.

Because you appear to be a novice with modern JavaScript, I will forgive your gauche semicolon usage. But watch yourself!